### PR TITLE
Created Application User with migrations

### DIFF
--- a/DisneyCafe/Data/ApplicationDbContext.cs
+++ b/DisneyCafe/Data/ApplicationDbContext.cs
@@ -14,5 +14,8 @@ namespace DisneyCafe.Data
         {
         }
         public DbSet<Ingredients> Ingredients { get; set; }
+        public DbSet<Desserts> Desserts { get; set; }
+        public DbSet<Orders> Orders { get; set; }
+        public DbSet<ApplicationUser> ApplicationUsers { get; set; }
     }
 }

--- a/DisneyCafe/Data/Migrations/20200224021641_AddingNewTables.Designer.cs
+++ b/DisneyCafe/Data/Migrations/20200224021641_AddingNewTables.Designer.cs
@@ -4,14 +4,16 @@ using DisneyCafe.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DisneyCafe.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200224021641_AddingNewTables")]
+    partial class AddingNewTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DisneyCafe/Data/Migrations/20200224021641_AddingNewTables.cs
+++ b/DisneyCafe/Data/Migrations/20200224021641_AddingNewTables.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DisneyCafe.Data.Migrations
+{
+    public partial class AddingNewTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAdmin",
+                table: "AspNetUsers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "AspNetUsers",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ApplicationUserId",
+                table: "AspNetRoles",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Desserts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(maxLength: 200, nullable: false),
+                    Description = table.Column<string>(maxLength: 3000, nullable: false),
+                    Price = table.Column<double>(nullable: false),
+                    Stock = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Desserts", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    OrderId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    OrderNumber = table.Column<string>(nullable: false),
+                    CustomerReferenceId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.OrderId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetRoles_ApplicationUserId",
+                table: "AspNetRoles",
+                column: "ApplicationUserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetRoles_AspNetUsers_ApplicationUserId",
+                table: "AspNetRoles",
+                column: "ApplicationUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetRoles_AspNetUsers_ApplicationUserId",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropTable(
+                name: "Desserts");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetRoles_ApplicationUserId",
+                table: "AspNetRoles");
+
+            migrationBuilder.DropColumn(
+                name: "IsAdmin",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "ApplicationUserId",
+                table: "AspNetRoles");
+        }
+    }
+}

--- a/DisneyCafe/Models/Database/ApplicationUser.cs
+++ b/DisneyCafe/Models/Database/ApplicationUser.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Identity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DisneyCafe.Models.Database
+{
+    /// <summary>
+    /// ApplicationUser inherits from IdentityUser to have access to the
+    /// user table
+    /// </summary>
+    public class ApplicationUser : IdentityUser
+    {
+        /// <summary>
+        /// Gets all roles associated from the user
+        /// </summary>
+        public List<IdentityRole> Roles { get; set; }
+        /// <summary>
+        /// If the user belongs to the Administrator role 
+        /// this will be true
+        /// </summary>
+        public bool IsAdmin { get; set; }
+    }
+}


### PR DESCRIPTION
closes #33 
Created the ApplicationUser's table which inherits from IdentityUser to allow access to tables generated from .NET Core. Also added migrations including all database tables up to the current commit.